### PR TITLE
Partial solution to calling `execute` several times

### DIFF
--- a/rerun
+++ b/rerun
@@ -42,8 +42,12 @@ function execute() {
 
 execute $@
 
+# stdbuf is from GNU coreutils.
+# https://stackoverflow.com/a/3373534/124946
+
 inotifywait --quiet --recursive --monitor --event modify --format "%w%f" . \
-| while read change; do
+| while read; do
+    date '+%s'
+done | stdbuf -oL uniq | while read; do
     execute $@
 done
-


### PR DESCRIPTION
This solution rate-limits the execution to only once per second.

It works by printing the current timestamp (number of seconds since epoch) whenever a change is detected, and then filtering it using `uniq` to execute only once per second. The `stdbuf` tool is required to force `uniq`'s `stdout` to be buffered line-wise.

Still not the best solution, but a simple and interesting solution.

---

I believe the best solution is to set a variable inside the loop and clear that variable inside the function. That way, there could be a conditional to only execute if the flag is clear.

A corner case would be if a file changes after the execution starts, but before the execution ends. Should the function be called again afterwards?
