### PR TITLE
Trying to reduce the amount of subprocesses inside the loop.

### DIFF
--- a/rerun
+++ b/rerun
@@ -53,6 +53,7 @@
 
 # Events that occur within this time from an initial one are ignored
 IGNORE_SECS=0.15
+IGNORE_NANOSECS="$(echo "$IGNORE_SECS" * 1000000000 | bc)"
 
 function execute() {
     clear
@@ -61,7 +62,7 @@ function execute() {
 }
 
 execute "$@"
-ignore_until=$(date +%s.%N)
+ignore_until=$(date +%s%N)
 
 inotifywait --quiet --recursive --monitor --format "%e %w%f" \
     --event modify --event move --event create --event delete \
@@ -70,8 +71,9 @@ do
 
     echo "$changed"
 
-    if [ $(echo " $(date +%s.%N) > $ignore_until" | bc) -eq 1 ] ; then
-        ignore_until=$(echo "$(date +%s.%N) + $IGNORE_SECS" | bc)
+    now_nanosecs="$(date +%s%N)"
+    if (( now_nanosecs > ignore_until )) ; then
+        let ignore_until=now_nanosecs+IGNORE_NANOSECS
         ( sleep $IGNORE_SECS ; execute "$@" ) &
     fi
 


### PR DESCRIPTION
I have one suggestion:

Since you are using `bash`, you can use [arithmetic](https://stackoverflow.com/questions/14511295/bash-integer-comparison) [evaluation](http://wiki.bash-hackers.org/syntax/arith_expr)/[expansion](http://tldp.org/LDP/abs/html/arithexp.html). This can replace the code that executes new processes (such as `bc`), which should reduce the overhead.

I see you are using "seconds.nanoseconds", and I believe bash does not support floating point. Well, you can concatenate as `+%s%N`, and convert IGNORE_SECS only once to nanoseconds, at the beginning. This way, you can work with plain integers in plain bash as much as possible.

I've changed this code directly in the browser. **I have not tested it.** It may or may not work. Most likely, this will break on systems that use 32-bit integers in bash.

Again, this is just a proposal, a food for thought, a way to share with you some tricks or some alternative solutions. I don't expect merging this pull request as is. :)
