### PR TITLE
Change watch target from "*" (all files in dir) to "." (current dir)

### DIFF
--- a/rerun
+++ b/rerun
@@ -67,7 +67,7 @@ ignore_until=$(date +%s.%N)
 inotifywait --quiet --recursive --monitor --format "%e %w%f" \
     --event modify --event move --event create --event delete \
     --exclude '__pycache__' \
-    * | while read changed
+    . | while read changed
 do
 
     echo "$changed"


### PR DESCRIPTION
rerun did not work for me with PyCharm (IntelliJ). Changing the watch target from `*` to `.` fixed it for me. The sequence of events when PyCharm updates a file is as follows:

```
CREATE ./script.py___jb_tmp___
MODIFY ./script.py___jb_tmp___
MOVED_FROM ./script.py
MOVED_TO ./script.py___jb_old___
MOVED_FROM ./script.py___jb_tmp___
MOVED_TO ./script.py
DELETE ./script.py___jb_old___
```
