### PR TITLE
fix: "invalid arithmetic operator" error

### DIFF
--- a/rerun2
+++ b/rerun2
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Events that occur within this time from an initial one are ignored
-ignore_msecs=250
+cooldown_s='0.250'
 clear='false'
 verbose='false'
 
@@ -11,15 +11,6 @@ then
     echo "error: inotifywait: command not found. hint: install inotify-tools"
     exit 1
 fi
-
-# int msecs -> float secs
-a=000$ignore_msecs
-a=${a:0: -3}
-while [ "${a:0:1}" = 0 ]; do a=${a:1}; done
-if [ -z "$a" ]; then a=0; fi
-b=000$ignore_msecs
-b=${b: -3}
-ignore_secs=$a.$b
 
 function usage {
     echo "Rerun a given command every time filesystem changes are detected."
@@ -33,7 +24,7 @@ function usage {
     echo ""
     echo "Run the given COMMAND, and then every time filesystem changes are"
     echo "detected in or below the current directory, run COMMAND again."
-    echo "Changes within $ignore_secs seconds are grouped into one."
+    echo "Changes within $cooldown_s seconds are grouped into one."
     echo ""
     echo "This is useful for running commands to regenerate visual output every"
     echo "time you hit [save] in your editor. For example, re-run tests, or"
@@ -77,7 +68,8 @@ function execute() {
 }
 
 execute "$@"
-ignore_until=$(date +%s.%N)
+end_of_cooldown="$( date +%s%N )"
+cooldown_ns="$( printf '%0.9f' "$cooldown_s" | sed -r -e 's|\.||' -e 's|^0+||' )"
 
 inotifywait --quiet --recursive --monitor --format "%e %w%f" \
     --event modify --event move --event create --event delete \
@@ -87,13 +79,10 @@ do
 
     changes="$changes\n$changed"
 
-    now_msecs=$(date +%s.%N)
-    now_msecs=${now_msecs/./}
-    now_msecs=${now_msecs:0: -6}
-
-    if (( now_msecs > ignore_until )); then
-        ignore_until=$(( now_msecs + ignore_msecs ))
-        ( sleep $ignore_secs ; execute "$@" ) &
+    now="$( date +%s%N )"
+    if (( now > end_of_cooldown )); then
+        end_of_cooldown="$(( now + cooldown_ns ))"
+        ( sleep "$cooldown_s" && execute "$@" ) &
     fi
 
 done

--- a/rerun2
+++ b/rerun2
@@ -2,8 +2,8 @@
 
 # Events that occur within this time from an initial one are ignored
 cooldown_s='0.250'
-clear='false'
-verbose='false'
+clear=''
+verbose=''
 
 # check dependencies
 if ! command -v inotifywait >/dev/null
@@ -45,8 +45,8 @@ function usage {
 
 while [ $# -gt 0 ]; do
     case "$1" in
-      -c|--clear) clear='true';;
-      -v|--verbose) verbose='true' ;;
+      -c|--clear) clear='1';;
+      -v|--verbose) verbose='1' ;;
       -h|--help) usage; exit;;
       *) break;;
     esac
@@ -54,10 +54,9 @@ while [ $# -gt 0 ]; do
 done
 
 function execute() {
-    if [ $clear = "true" ]; then
-        clear
-    fi
-    if [ $verbose = "true" ]; then
+    [ -n "$clear" ] && clear
+
+    if [ -n "$verbose" ]; then
         if [ -n "$changes" ]; then
             echo -e "Changed: $(echo -e $changes | cut -d' ' -f2 | sort -u | tr '\n' ' ')"
             changes=""

--- a/rerun2
+++ b/rerun2
@@ -58,11 +58,12 @@ function execute() {
 
     if [ -n "$verbose" ]; then
         if [ -n "$changes" ]; then
-            echo -e "Changed: $(echo -e $changes | cut -d' ' -f2 | sort -u | tr '\n' ' ')"
+            echo -e "Changed: $( echo -e $changes | cut -d' ' -f2 | sort -u | tr '\n' ' ' )"
             changes=""
         fi
         echo "$@"
     fi
+
     "$@"
 }
 
@@ -70,9 +71,9 @@ execute "$@"
 end_of_cooldown="$( date +%s%N )"
 cooldown_ns="$( printf '%0.9f' "$cooldown_s" | sed -r -e 's|\.||' -e 's|^0+||' )"
 
-inotifywait --quiet --recursive --monitor --format "%e %w%f" \
-    --event modify --event move --event create --event delete \
-    --exclude '(\..*\.swp|__pycache__|\.cache|\.pytest_cache)' \
+inotifywait --quiet --recursive --monitor --format '%e %w%f' \
+    --event='modify' --event='move' --event='create' --event='delete' \
+    --exclude='(\..*\.swp|__pycache__|\.cache|\.pytest_cache)' \
     . | while read changed
 do
 


### PR DESCRIPTION
Fixes #13.

This also eliminates a lot of string manipulation by defining the cooldown in seconds and doing all comparisons on nanosecond timestamps. It does introduce one `printf` call and one `sed` invocation, but these happen outside of the inotify/wait loop, so are only called *once*.

Worth noting:
- I've renamed "ignore" to "cooldown" for clarity.
- I've renamed "ignore_until" to "end_of_cooldown" for clarity.
- I've simplified parameter handling by allowing for `-n`/`-z` checks instead of `== "true"`/`== "false"`.

---

If/when this PR is approved and merged, I'll have a follow-up PR for several issues I've identified relating to `--verbose` behaviour (and `$changes` management) being broken:
- When `--verbose` is *not* in play, the `$changes` variable is (unnecessarily) written to and never cleared. This results in runaway memory usage on (very long running) `rerun2` instances.
- When `--verbose` *is* in play, the `$changes` variable is **never actually cleared** within the `execute` function due to it being run from within a subshell. I've spent hours researching a fix for this, and the only solution I've landed on is that the `$changes` data should actually reside within a temp file\* so that it is accessible and manipulatable both within the inotify/wait loop *and* within the `execute` function.
- Due to the fact that (at least) `$cooldown_s` seconds elapse between when the subshell is spawned and when the `execute` function *runs*, any inotify events that happen in the meantime (i.e. during the cooldown/wait period) are not known to `execute` when it reports what changes have been seen. (The version of `$changes` in the inotify/wait loop *is* being updated during this time, but the shell doesn't see these changes as it was spawned in the past.) These will then be reported during the **next** `execute` call, which won't happen until an indeterminate time in the future. Again, storing the `$changes` data in a temp file\*  instead will correct this issue as well.

\* Note that by "temp file" I mean an actual temp file *or* possibly a shared memory location that is accessible across the two shells. Again, this will be implemented in a forthcoming PR and I'll be sure to document how/why I landed on one option vs the other.