### PR TITLE
Fixed error: printf: 0.250: invalid number

### DIFF
--- a/rerun2
+++ b/rerun2
@@ -61,7 +61,7 @@ function execute() {
 
 execute "$@"
 end_of_cooldown="$( date +%s%N )"
-cooldown_ns="$( printf '%0.9f' "$cooldown_s" | sed -r -e 's|\.||' -e 's|^0+||' )"
+cooldown_ns="$( LC_ALL=C printf '%0.9f' "$cooldown_s" | sed -r -e 's|\.||' -e 's|^0+||' )"
 
 inotifywait --quiet --recursive --monitor --format '%e %w%f' \
     --event='modify,close_write,move,create,delete' \


### PR DESCRIPTION
When running `rerun2` on my system:

    /home/denilsonsa/bin/rerun2: line 64: printf: 0.250: invalid number

This unfortunately seems to happen due to some locale setting that makes comma as the decimal separator:

    LC_NUMERIC=nl_NL.UTF-8

Alternatively, we could directly specify the cooldown constant as nanoseconds, avoiding the conversion done through `printf` and `sed`.